### PR TITLE
MIFOS-1980: customer schedule after customer moved to group updates correctly

### DIFF
--- a/appdomain/src/main/java/org/mifos/customers/business/CustomerBO.java
+++ b/appdomain/src/main/java/org/mifos/customers/business/CustomerBO.java
@@ -1302,6 +1302,13 @@ public abstract class CustomerBO extends AbstractBusinessObject {
             throw new CustomerException(CustomerConstants.INVALID_PARENT);
         }
     }
+    
+    public boolean isTopOfHierarchy() {
+    	if (this.parentCustomer == null) {
+    		return true;
+    	}
+    	return false;
+    }
 
     public boolean hasMeetingDifferentTo(MeetingBO groupMeeting) {
         MeetingBO customerMeeting = getCustomerMeetingValue();
@@ -1352,5 +1359,18 @@ public abstract class CustomerBO extends AbstractBusinessObject {
             }           
         }
         return activeAccountExits;
+    }
+    
+    /**
+     * Checks if there are any active periodic fees for customer.
+     * @return true if at least one active and periodic fee is found, otherwise false
+     */
+    public boolean isAnyPeriodicFeeActive() {
+    	for (AccountBO account : getAccounts()) {
+    		if(!account.isAnyPeriodicFeeActive()) {
+    			return true;
+    		}
+    	}
+    	return false;
     }
 }

--- a/appdomain/src/main/java/org/mifos/customers/business/service/CustomerServiceImpl.java
+++ b/appdomain/src/main/java/org/mifos/customers/business/service/CustomerServiceImpl.java
@@ -29,6 +29,7 @@ import org.joda.time.DateMidnight;
 import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.joda.time.LocalDate;
+import org.mifos.accounts.business.AccountActionDateEntity;
 import org.mifos.accounts.business.AccountBO;
 import org.mifos.accounts.business.AccountFeesEntity;
 import org.mifos.accounts.exceptions.AccountException;
@@ -950,7 +951,9 @@ public class CustomerServiceImpl implements CustomerService {
         GroupBO receivingGroup = (GroupBO) customerDao.findCustomerById(groupId);
         client.validateReceivingGroup(receivingGroup);
         client.validateForActiveAccounts();
+        client.validateForPeriodicFees();
 
+        	
         CustomerBO oldParent = client.getParentCustomer();
 
         try {
@@ -1155,7 +1158,7 @@ public class CustomerServiceImpl implements CustomerService {
             if (account instanceof LoanBO && lsimEnabled) {
                 // do not change schedules when LSIm is on for loan accounts
             } else {
-                account.handleChangeInMeetingSchedule(workingDays, orderedUpcomingHolidays);
+                account.handleChangeInMeetingSchedule(workingDays, orderedUpcomingHolidays, customer.isTopOfHierarchy());
                 customerDao.save(account);
             }
         }

--- a/appdomain/src/main/java/org/mifos/customers/client/business/ClientBO.java
+++ b/appdomain/src/main/java/org/mifos/customers/client/business/ClientBO.java
@@ -757,8 +757,14 @@ public class ClientBO extends CustomerBO {
     public void validateForActiveAccounts() throws CustomerException {
         if (isAnyAccountActive()) {
             throw new CustomerException(ClientConstants.ERRORS_ACTIVE_ACCOUNTS_PRESENT,
-                    new Object[] { ApplicationContextProvider.getBean(MessageLookup.class).lookupLabel(ConfigurationConstants.GROUP) });
+            		new Object[] { ApplicationContextProvider.getBean(MessageLookup.class).lookupLabel(ConfigurationConstants.GROUP) });
         }
+    }
+    
+    public void validateForPeriodicFees() throws CustomerException {
+    	if (isAnyPeriodicFeeActive()) {
+    		throw new CustomerException(ClientConstants.ERRORS_ACTIVE_PERIODIC_FEES_PRESENT);
+    	}
     }
 
     private void validateBranchTransfer(final OfficeBO officeToTransfer) throws CustomerException {

--- a/appdomain/src/main/java/org/mifos/customers/client/util/helpers/ClientConstants.java
+++ b/appdomain/src/main/java/org/mifos/customers/client/util/helpers/ClientConstants.java
@@ -184,6 +184,7 @@ public interface ClientConstants {
     String ERRORS_GROUP_CANCELLED = "errors.Client.groupCancelled";
     String ERRORS_LOWER_GROUP_STATUS = "errors.Client.lowerGroupStatus";
     String ERRORS_ACTIVE_ACCOUNTS_PRESENT = "errors.Client.hasActiveAccount";
+    String ERRORS_ACTIVE_PERIODIC_FEES_PRESENT = "errors.Client.hasActivePeriodicFees";
     String ERRORS_DUPLICATE_OFFERING_SELECTED = "errors.Client.duplicateOfferingSelected";
 
     String CLIENTPERFORMANCEHISTORY = "ClientPerformanceHistory";

--- a/application/src/main/resources/org/mifos/config/localizedResources/ClientUIResources.properties
+++ b/application/src/main/resources/org/mifos/config/localizedResources/ClientUIResources.properties
@@ -350,6 +350,7 @@ error.unknownexception=<li>Unknown Exception occurred.</li>
 error.versionnodonotmatch=The record has already been modified by another user. Please navigate to the details page and start the activity again.
 errors.Client.duplicateOfferingSelected=<li>The same {0} product cannot be selected multiple times.</li>
 errors.Client.hasActiveAccount=<li>{0} Membership cannot be changed, as Active accounts exist.</li>
+errors.Client.hasActivePeriodicFees=<li>Membership to group with different meeting frequency cannot be changed, as active periodic fees exist.</li>
 errors.Client.lowerGroupStatus=<li>Group status should be higher than that of Client</li>
 errors.Customer.duplicatePeriodicFee=<li>Same periodic fee cannot be selected multiple times.</li>
 errors.Customer.feeFrequencyMismatch=<li>Meeting frequency and fee recurrence do not match. Please select only valid fee types.</li>

--- a/application/src/test/java/org/mifos/accounts/AccountRegenerateScheduleIntegrationTestCase.java
+++ b/application/src/test/java/org/mifos/accounts/AccountRegenerateScheduleIntegrationTestCase.java
@@ -440,9 +440,10 @@ public class AccountRegenerateScheduleIntegrationTestCase extends MifosIntegrati
 
         List<Days> workingDays = new FiscalCalendarRules().getWorkingDaysAsJodaTimeDays();
         List<Holiday> holidays = new ArrayList<Holiday>();
-        center.getCustomerAccount().handleChangeInMeetingSchedule(workingDays, holidays);
-        accountBO.handleChangeInMeetingSchedule(workingDays, holidays);
-        savingsBO.handleChangeInMeetingSchedule(workingDays, holidays);
+        boolean isTopOfHierarchy = center.isTopOfHierarchy();
+        center.getCustomerAccount().handleChangeInMeetingSchedule(workingDays, holidays, isTopOfHierarchy);
+        accountBO.handleChangeInMeetingSchedule(workingDays, holidays, isTopOfHierarchy);
+        savingsBO.handleChangeInMeetingSchedule(workingDays, holidays, isTopOfHierarchy);
 
         StaticHibernateUtil.flushSession();
     }

--- a/application/src/test/java/org/mifos/customers/client/struts/action/ClientTransferActionStrutsTest.java
+++ b/application/src/test/java/org/mifos/customers/client/struts/action/ClientTransferActionStrutsTest.java
@@ -21,6 +21,7 @@
 package org.mifos.customers.client.struts.action;
 
 import java.io.IOException;
+import java.sql.Date;
 import java.util.List;
 
 import junit.framework.Assert;
@@ -264,7 +265,7 @@ public class ClientTransferActionStrutsTest extends MifosMockStrutsTestCase {
         group = TestObjectFactory.createWeeklyFeeGroupUnderCenter("Group", CustomerStatus.GROUP_ACTIVE, center);
         center1 = TestObjectFactory.createWeeklyFeeCenter("Center1", meeting1);
         group1 = TestObjectFactory.createWeeklyFeeGroupUnderCenter("Group2", CustomerStatus.GROUP_ACTIVE, center1);
-        client = TestObjectFactory.createClient("Client11", CustomerStatus.CLIENT_ACTIVE, group);
+        client = TestObjectFactory.createClient("Client11", CustomerStatus.CLIENT_ACTIVE, group, null, (String) null, new Date(1222333444000L));
         StaticHibernateUtil.flushSession();
     }
 


### PR DESCRIPTION
this commit is imposing new restriction for changing customer group - client cannot have any active periodic fee

commit separates two different meeting schedule update types:

1) for customers being at the top of hierarchy (mainly centers), anywhere where we can edit meeting schedule from customer's detail page -> this should be update like functional specification says
http://mifos.org/functional-specifications/mfi-information-setup/meetings

2) for customers who are switching their membership (eg client switching group), their meeting schedule should be updated from the day that group change is made
Note that those customers cannot have any active loan accounts or any active periodic fees so we treat them like new customers
Their disbursement date will be correct then

Changing group's center membership for one with different meeting frequency is still blocked

Acceptance test included
