### PR TITLE
MIFOS-5078: Fixed incorrect error message for Administrative fee

### DIFF
--- a/userInterface/src/main/java/org/mifos/clientportfolio/loan/ui/LoanAccountFormBean.java
+++ b/userInterface/src/main/java/org/mifos/clientportfolio/loan/ui/LoanAccountFormBean.java
@@ -475,7 +475,7 @@ public class LoanAccountFormBean implements Serializable {
                                             "selectedFeeId",
                                             "loanAccountFormBean.defaultfees.amountOrRate.digits.before.decimal.invalid",
                                             new Object[] { Integer.valueOf(defaultFeeIndex + 1),
-                                                    this.digitsAfterDecimalForMonetaryAmounts },
+                                                    this.digitsBeforeDecimalForMonetaryAmounts },
                                             "Please specify fee amount for additional fee "
                                                     + Integer.valueOf(defaultFeeIndex + 1).toString());
                                 }


### PR DESCRIPTION
MIFOS-5078: Fixed incorrect error message for Administrative fee on 'Enter Loan account information' page.
