### PR TITLE
MIFOS-5729: can create new loan without "Can define hidden/mandatory fields" permission

### DIFF
--- a/serviceInterfaces/src/main/java/org/mifos/application/admin/servicefacade/AdminServiceFacade.java
+++ b/serviceInterfaces/src/main/java/org/mifos/application/admin/servicefacade/AdminServiceFacade.java
@@ -86,7 +86,7 @@ public interface AdminServiceFacade {
     @PreAuthorize("isFullyAuthenticated()")
     boolean isHiddenMandatoryField(String fieldName);
     
-    @PreAuthorize("isFullyAuthenticated() and hasRole('ROLE_CAN_DEFINE_HIDDEN_MANDATORY_FIELDS')")
+    @PreAuthorize("isFullyAuthenticated()")
     MandatoryHiddenFieldsDto retrieveHiddenMandatoryFields();
 
     @PreAuthorize("isFullyAuthenticated() and hasRole('ROLE_CAN_DEFINE_HIDDEN_MANDATORY_FIELDS')")


### PR DESCRIPTION
OK, I have removed permission restriction for read only stuff

some forms are using retrieveHiddenMandatoryFields() method for retrieving information about hidden and mandatory fields and they are throwing access denied exceptions when cannot reach that method - as a result we are not able to use this forms without 'Can define hidden/mandatory fields' permission

PS after my change it is still not possible to define hidden/mandatory fields without permission
