### PR TITLE
 MIFOS-5645:Changed color of warning message

### DIFF
--- a/userInterface/src/main/resources/org/mifos/ui/freemarker/core/fundTransferEnterDetails.ftl
+++ b/userInterface/src/main/resources/org/mifos/ui/freemarker/core/fundTransferEnterDetails.ftl
@@ -45,7 +45,7 @@
 <br />
 
 [#if targetAccount.accountStateId == 18]
-	<p><b>[@spring.message "fundTransfer.inactiveBeneficiaryAcc" /]</b></p>
+	<p class="fontnormalRedBold">[@spring.message "fundTransfer.inactiveBeneficiaryAcc" /]</p>
 [/#if]
 
 [@form.errors "fundTransferFormBean.*"/]


### PR DESCRIPTION
Changed the color of message: "Warning: Selected account is inactive, it will be reactivated." to red.
File changed: userInterface/src/main/resources/org/mifos/ui/freemarker/core/fundTransferEnterDetails.ftl
