### PR TITLE
MIFOS-5637: Fixed too big space between number and Customer name

### DIFF
--- a/userInterface/src/main/resources/META-INF/resources/pages/css/app.css
+++ b/userInterface/src/main/resources/META-INF/resources/pages/css/app.css
@@ -225,9 +225,9 @@ form.two-columns input.disabledbuttn
     font-weight: bold;
 }
 
-.search-results td
-{
-    padding: 3px 0px 5px 1px;
+.search-results tr > td:first-child 
+{ 
+    width: 1px ;  
 }
 
 .mandatory {


### PR DESCRIPTION
Fixed too big space between number and Customer name in search results.
This space is now smaller and always the same (not depending on page number or browser window's width)
Looks fine on Chromium and Firefox, but I'm not sure about IE.
