### PR TITLE
MIFOS-5743: Fixed validation message to appear correctly.

### DIFF
--- a/application/src/main/resources/org/mifos/config/localizedResources/accountsUIResources.properties
+++ b/application/src/main/resources/org/mifos/config/localizedResources/accountsUIResources.properties
@@ -339,6 +339,7 @@ errors.payment.date.before.last.payment={0} cannot be less than the last payment
 errors.payment.noAccountForTransfer=Please select an account for fund transfer
 errors.generic=The {0} is invalid because {1}
 errors.insufficentbalance=Not enough balance in the savings account, please select a different account
+errors.exceedmaxwithdrawal=Withdrawal can not be done. Specified amount is greater than the withdrawal limit.
 errors.integer=Please specify valid {0}. Use numbers only.
 errors.invalidTxndate=Date of transaction is invalid. It can not be prior to last meeting date of the customer.
 errors.invalidTxndateMonthAlreadyClosed=Date of transaction is invalid. This date has already been closed for accounting.


### PR DESCRIPTION
Fixed validation message to appear correctly when trying to make transfer from savings for amount bigger than Max amount per withdrawal.

Message was copied from another .properties file and says: 
"Withdrawal can not be done. Specified amount is greater than the withdrawal limit."
