### PR TITLE
MIFOS-5852: Enabled test newMonthlyClientLoanAccountWithMeetingOnSameWee...

### DIFF
--- a/acceptanceTests/src/test/java/org/mifos/test/acceptance/loan/lsim/CreateLSIMClientLoanAccountTest.java
+++ b/acceptanceTests/src/test/java/org/mifos/test/acceptance/loan/lsim/CreateLSIMClientLoanAccountTest.java
@@ -129,7 +129,8 @@ public class CreateLSIMClientLoanAccountTest extends UiTestCaseBase {
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     // one of the dependent methods throws Exception
-    @Test(enabled=false) //TODO http://mifosforge.jira.com/browse/MIFOS-5081
+    // https://mifosforge.jira.com/browse/MIFOS-5852
+    @Test(enabled=true)
     public void newMonthlyClientLoanAccountWithMeetingOnSameWeekAndWeekday() throws Exception {
         CreateLoanAccountSearchParameters searchParameters = new CreateLoanAccountSearchParameters();
         searchParameters.setSearchString("Monthly3rdFriday");


### PR DESCRIPTION
...kAndWeekday, since dependent methods throw no more exceptions.
