### PR TITLE
MIFOS-5639: Remove Status for which checklist is already defined

### DIFF
--- a/application/src/main/java/org/mifos/customers/checklist/struts/action/ChkListAction.java
+++ b/application/src/main/java/org/mifos/customers/checklist/struts/action/ChkListAction.java
@@ -400,9 +400,33 @@ public class ChkListAction extends BaseAction {
         if (isCustomer) {
             Short levelId = getShortValue(masterTypeId);
             states = this.checkListServiceFacade.retrieveAllCustomerStates(levelId);
+            List<CustomerCheckBoxItemDto> customerCheckLists = filterCustomerCheckListsByLevel(
+                    checkListServiceFacade.retreiveAllCustomerCheckLists(), CustomerLevel.getLevel(levelId));
+
+            for (int i = states.size() - 1; i >= 0; i--) {
+                Short state = states.get(i).getStateId();
+
+                for (CustomerCheckBoxItemDto customer : customerCheckLists) {
+                    if (state.equals(customer.getCustomerStatusId())) {
+                        states.remove(i);
+                    }
+                }
+            }
         } else {
             Short prdTypeId = getShortValue(masterTypeId);
             states = this.checkListServiceFacade.retrieveAllAccountStates(prdTypeId);
+            List<AccountCheckBoxItemDto> accountCheckLists = filterAccountCheckListsByProductType(
+                    checkListServiceFacade.retreiveAllAccountCheckLists(), ProductType.fromInt((int) prdTypeId));
+
+            for (int i = states.size() - 1; i >= 0; i--) {
+                Short state = states.get(i).getStateId();
+
+                for (AccountCheckBoxItemDto account : accountCheckLists) {
+                    if (state.equals(account.getAccountStateId())) {
+                        states.remove(i);
+                    }
+                }
+            }
         }
 
         return states;

--- a/application/src/test/java/org/mifos/customers/checklist/struts/action/CheckListActionStrutsTest.java
+++ b/application/src/test/java/org/mifos/customers/checklist/struts/action/CheckListActionStrutsTest.java
@@ -154,6 +154,50 @@ public class CheckListActionStrutsTest extends MifosMockStrutsTestCase {
        Assert.assertEquals(5, ((List<CheckListStatesView>) SessionUtils.getAttribute(CheckListConstants.STATES, request))
                 .size());
     }
+    
+    @Test
+    public void testGetStatesDuplicateForCustomer() throws Exception {
+        CustomerCheckListBO checkList = TestObjectFactory.createCustomerChecklist(CustomerLevel.GROUP.getValue(),
+                CustomerStatus.GROUP_ACTIVE.getValue(), (short) 1);
+        StaticHibernateUtil.flushSession();
+        setRequestPathInfo("/chkListAction");
+        addRequestParameter("method", "getStates");
+        addRequestParameter("masterTypeId", "2");
+        addRequestParameter("isCustomer", "true");
+        addRequestParameter(Constants.CURRENTFLOWKEY, flowKey);
+        actionPerform();
+        verifyNoActionErrors();
+        verifyForward(ActionForwards.load_success.toString());
+        Assert.assertNotNull(request.getAttribute(Constants.CURRENTFLOWKEY));
+        List<CheckListStatesView> states = (List<CheckListStatesView>) SessionUtils.getAttribute(
+                CheckListConstants.STATES, request);
+
+        for (CheckListStatesView state : states) {
+            Assert.assertNotSame(state.getStateId(), checkList.getCustomerStatus().getId());
+        }
+    }
+
+    @Test
+    public void testGetStatesDuplicateForAccount() throws Exception {
+        AccountCheckListBO checkList = TestObjectFactory.createAccountChecklist(ProductType.LOAN.getValue(),
+                AccountState.LOAN_APPROVED, (short) 1);
+        StaticHibernateUtil.flushSession();
+        setRequestPathInfo("/chkListAction");
+        addRequestParameter("method", "getStates");
+        addRequestParameter("masterTypeId", "1");
+        addRequestParameter("isCustomer", "false");
+        addRequestParameter(Constants.CURRENTFLOWKEY, flowKey);
+        actionPerform();
+        verifyNoActionErrors();
+        verifyForward(ActionForwards.load_success.toString());
+        Assert.assertNotNull(request.getAttribute(Constants.CURRENTFLOWKEY));
+        List<CheckListStatesView> states = (List<CheckListStatesView>) SessionUtils.getAttribute(
+                CheckListConstants.STATES, request);
+
+        for (CheckListStatesView state : states) {
+            Assert.assertNotSame(state.getStateId(), checkList.getAccountStateEntity().getId());
+        }
+    }
 
     @Test
     public void testPreviewNoChecklistName() {


### PR DESCRIPTION
Remove Status for which checklist is already defined from Displayed when moving into Status dropdown
