### PR TITLE
Fixed MIFOS-5995: Error with Data Import

### DIFF
--- a/acceptanceTests/src/test/java/org/mifos/test/acceptance/admin/RolesAndPermissionTest.java
+++ b/acceptanceTests/src/test/java/org/mifos/test/acceptance/admin/RolesAndPermissionTest.java
@@ -57,6 +57,7 @@ public class RolesAndPermissionTest extends UiTestCaseBase {
     private final static String officeName = "test_office";
     private final static String clientName = "test client";
     private final static String userName = "test user";
+    static final int WEEKLY_RECURRENCE_TYPE_ID = 1;
 
     @Override
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")    // one of the dependent methods throws Exception
@@ -86,7 +87,7 @@ public class RolesAndPermissionTest extends UiTestCaseBase {
     public void adjustmentOfPostDatedTransactions() throws Exception {
         navigationHelper.navigateToAdminPage().navigateToViewRolesPage().navigateToManageRolePage("Admin").disablePermission("5_1_9").
                 verifyPermissionText("5_1_9", "Can adjust back dated transactions").submitAndGotoViewRolesPage();
-        DefineNewLoanProductPage.SubmitFormParameters formParameters = loanProductTestHelper.defineLoanProductParameters(5, 1000, 20, DefineNewLoanProductPage.SubmitFormParameters.DECLINING_BALANCE_INTEREST_RECALCULATION);
+        DefineNewLoanProductPage.SubmitFormParameters formParameters = loanProductTestHelper.defineLoanProductParameters(5, 1000, 20, DefineNewLoanProductPage.SubmitFormParameters.DECLINING_BALANCE_INTEREST_RECALCULATION, WEEKLY_RECURRENCE_TYPE_ID);
         loanProductTestHelper.
                 navigateToDefineNewLoanPageAndFillMandatoryFields(formParameters).
                 submitAndGotoNewLoanProductPreviewPage().submit();

--- a/acceptanceTests/src/test/java/org/mifos/test/acceptance/loan/CreateClientLoanAccountTest.java
+++ b/acceptanceTests/src/test/java/org/mifos/test/acceptance/loan/CreateClientLoanAccountTest.java
@@ -84,6 +84,7 @@ public class CreateClientLoanAccountTest extends UiTestCaseBase {
     private LoanProductTestHelper loanProductTestHelper;
     private NavigationHelper navigationHelper;
     private FeeTestHelper feeTestHelper;
+    static final int WEEKLY_RECURRENCE_TYPE_ID = 1;
 
     @Autowired
     private DriverManagerDataSource dataSource;
@@ -717,7 +718,7 @@ public class CreateClientLoanAccountTest extends UiTestCaseBase {
                 FeesCreatePage.SubmitFormParameters.LOAN_AMOUNT_INTEREST);
         SubmitFormParameters dbIrLoanProductParams = loanProductTestHelper.defineLoanProductParameters(
                 numberOfInstallments, loanAmount, interestRate,
-                DefineNewLoanProductPage.SubmitFormParameters.DECLINING_BALANCE_INTEREST_RECALCULATION);
+                DefineNewLoanProductPage.SubmitFormParameters.DECLINING_BALANCE_INTEREST_RECALCULATION, WEEKLY_RECURRENCE_TYPE_ID);
         dbIrLoanProductParams.setOfferingName("DbIrProduct5629");
         loanProductTestHelper.defineNewLoanProduct(dbIrLoanProductParams);
         CreateLoanAccountSearchParameters searchParameters = new CreateLoanAccountSearchParameters();

--- a/acceptanceTests/src/test/java/org/mifos/test/acceptance/loan/DecliningPrincipleLoanTest.java
+++ b/acceptanceTests/src/test/java/org/mifos/test/acceptance/loan/DecliningPrincipleLoanTest.java
@@ -64,6 +64,7 @@ public class DecliningPrincipleLoanTest extends UiTestCaseBase {
     private final static String LOAN_CLOSED = "Closed- Obligation met";
     private final static String LOAN_ACTIVE_GOOD = "Active in Good Standing";
     private final static String LOAN_ACTIVE_BAD = "Active in Bad Standing";
+    static final int WEEKLY_RECURRENCE_TYPE_ID = 1;
 
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")    // one of the dependent methods throws Exception
     @AfterMethod
@@ -93,7 +94,7 @@ public class DecliningPrincipleLoanTest extends UiTestCaseBase {
     @Test(enabled=true)
     public void verifyDecliningPrincipleLoan() throws Exception {
         applicationDatabaseOperation.updateLSIM(1);
-        DefineNewLoanProductPage.SubmitFormParameters formParameters = loanProductTestHelper.defineLoanProductParameters(3, 1000, 20, interestType);
+        DefineNewLoanProductPage.SubmitFormParameters formParameters = loanProductTestHelper.defineLoanProductParameters(3, 1000, 20, interestType, WEEKLY_RECURRENCE_TYPE_ID);
         loanProductTestHelper.
                 navigateToDefineNewLoanPageAndFillMandatoryFields(formParameters).
                 submitAndGotoNewLoanProductPreviewPage().

--- a/acceptanceTests/src/test/java/org/mifos/test/acceptance/loanproduct/LoanProductTestHelper.java
+++ b/acceptanceTests/src/test/java/org/mifos/test/acceptance/loanproduct/LoanProductTestHelper.java
@@ -47,9 +47,23 @@ public class LoanProductTestHelper {
     }
 
     public DefineNewLoanProductPage.SubmitFormParameters defineLoanProductParameters(int defInstallments,
-            int defaultLoanAmount, int defaultInterestRate, int interestType) {
-        DefineNewLoanProductPage.SubmitFormParameters formParameters = FormParametersHelper
-                .getWeeklyLoanProductParameters();
+            int defaultLoanAmount, int defaultInterestRate, int interestType, int recurrenceTypeId) {
+        DefineNewLoanProductPage.SubmitFormParameters formParameters = null;
+
+        switch (recurrenceTypeId) {
+        case 1:
+            formParameters = FormParametersHelper.getWeeklyLoanProductParameters();
+            break;
+        case 2:
+            formParameters = FormParametersHelper.getMonthlyLoanProductParameters();
+            break;
+        case 3:
+            formParameters = FormParametersHelper.getDailyLoanProductParameters();
+            break;
+        default:
+            break;
+        }
+        
         formParameters.setDefInstallments(String.valueOf(defInstallments));
         formParameters.setDefaultLoanAmount(String.valueOf(defaultLoanAmount));
         formParameters.setInterestTypes(interestType);


### PR DESCRIPTION
Fixed import issue with loan repayment schedule set to monthly and LSIM enabled.
Additionally fixed import to handle weekly and daily schedules for both LSIM enabled and disabled correctly.
Modified existing acceptance test to also handle relevant cases with LSIM enabled.
